### PR TITLE
Add tern-org ontology viewer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -95,7 +95,11 @@ const config = {
               {
                 to: '/viewers/tern-loc-ontology',
                 label: 'Browse TERN Location Ontology by class'
-              }
+              },
+              {
+                to: '/viewers/tern-org-ontology',
+                label: 'Browse TERN Organisation Ontology by class'
+              },
             ]
           },
           {

--- a/src/components/IRIField.js
+++ b/src/components/IRIField.js
@@ -23,7 +23,7 @@ export default function IRIField({ value, settings }) {
   }
   const { data, error } = useSWR(endpoint + '?' + searchParams, fetcher, swrOptions)
 
-  const errorView = <code>{value}</code>
+  const errorView = <ExternalLink href={value}>{value}</ExternalLink>
 
   if (error) return errorView
   if (!data) return <div>Loading...</div>

--- a/src/pages/viewers/tern-ontology/_queries.js
+++ b/src/pages/viewers/tern-ontology/_queries.js
@@ -37,6 +37,9 @@ export function getTopLevelClasses() {
         FILTER(isIRI(?parentClass))        
     }
 
+    FILTER(!isBlank(?class))
+    FILTER(STRSTARTS(STR(?class), "${baseUri}"))
+
     FILTER NOT EXISTS {
         ?class rdfs:subClassOf ?other .
         FILTER(STRSTARTS(STR(?other), "${baseUri}"))

--- a/src/pages/viewers/tern-org-ontology/_queries.js
+++ b/src/pages/viewers/tern-org-ontology/_queries.js
@@ -1,4 +1,4 @@
-export const baseUri = 'https://w3id.org/tern/ontologies/loc/'
+export const baseUri = 'https://w3id.org/tern/ontologies/org/'
 const namedGraph = baseUri
 
 export function getDirectSubclasses(resourceUri) {
@@ -10,7 +10,7 @@ export function getDirectSubclasses(resourceUri) {
   from <${namedGraph}>
   WHERE {
     ?directChildClass rdfs:subClassOf <${resourceUri}> .
-    ?directChildClass a sh:NodeShape .
+    ?directChildClass a owl:Class .
     
     BIND(
         EXISTS {
@@ -31,7 +31,7 @@ export function getTopLevelClasses() {
   from <http://www.ontotext.com/explicit>
   from <${namedGraph}>
   where {
-    ?class a sh:NodeShape .
+    ?class a owl:Class .
     optional {
         ?class rdfs:subClassOf ?parentClass .
         FILTER(isIRI(?parentClass))        

--- a/src/pages/viewers/tern-org-ontology/_settings.js
+++ b/src/pages/viewers/tern-org-ontology/_settings.js
@@ -1,0 +1,9 @@
+import * as queries from './_queries'
+
+const settings = {
+  title: 'TERN Organisation Ontology viewer',
+  pageRoute: '/viewers/tern-org-ontology',
+  endpoint: 'https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false',
+  queries: queries
+}
+export default settings

--- a/src/pages/viewers/tern-org-ontology/index.js
+++ b/src/pages/viewers/tern-org-ontology/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import ViewerPage from '../../../components/viewers/Page'
+import settings from './_settings'
+
+export default function Page() {
+  return (
+    <ViewerPage settings={settings} />
+  )
+}


### PR DESCRIPTION
- Add TERN Organisation Ontology viewer
- Render as ExternalLink instead of <code> for URIs not found with the external prefix server.