### PR TITLE
Remove deprecated invertebrate submodules

### DIFF
--- a/information-models/tern-ontology/dev-guide/dawe-protocol/invertebrate/eDNA.md
+++ b/information-models/tern-ontology/dev-guide/dawe-protocol/invertebrate/eDNA.md
@@ -1,3 +1,0 @@
-# eDNA
-
-This module contains no observations.

--- a/information-models/tern-ontology/dev-guide/dawe-protocol/invertebrate/foliage-beating.md
+++ b/information-models/tern-ontology/dev-guide/dawe-protocol/invertebrate/foliage-beating.md
@@ -1,3 +1,0 @@
-# Foliage Beating
-
-This module contains no observations.

--- a/information-models/tern-ontology/dev-guide/dawe-protocol/invertebrate/sweep-netting.md
+++ b/information-models/tern-ontology/dev-guide/dawe-protocol/invertebrate/sweep-netting.md
@@ -1,3 +1,0 @@
-# Sweet Netting
-
-This module contains no observations.


### PR DESCRIPTION
Action based on email from Ecosystem Surveillance:

> The priority protocols in the invertebrate module are micro-pitfall and active sampling (as these are the ‘mandatory’ methods if undertaking the Invertebrate Module).
Rename micro-pitfall protocol to wet pitfall protocol.
Remove the eDNA, foliage beating and sweep netting protocols. Foliage beat and sweep net will instead be included as sampling options within the active search protocol - I have created a categorical list with all the sampling method options for active sampling.
The eDNA protocol is premature (I feel there is more work required outside of our capability before developing into a protocol) so best to drop it for now.

> Some of the fields/vocabs could change down as this has been done very much on the fly but will have to run with it for now.

This PR removes the pages for eDNA, foliage beating and sweep netting protocols within the Invertebrate module.