### PR TITLE
Updated the overview table query to fetch feature type from metadata

### DIFF
--- a/src/components/docs/tern-ontology/rlp-protocol/settings.js
+++ b/src/components/docs/tern-ontology/rlp-protocol/settings.js
@@ -15,7 +15,9 @@ where {
     bind(str(?_label) as ?__label)
 
     optional { 
-        ?concept tern:hasFeatureType ?featureType .
+      ?metadata <urn:property:featureType> ?featureType ;
+      <urn:property:observableProperty> ?concept ;
+      <urn:property:observablePropertiesCollection> <${moduleOpCollectionUri}> .
         service <https://graphdb.tern.org.au/repositories/tern_vocabs_core> {
             ?featureType skos:prefLabel ?_featureTypeLabel .
         }


### PR DESCRIPTION
Each observable property can have different feature types in different modules. 

This PR updated the query to fetch feature type from metadata, which has module specific information.