### PR TITLE
Set provenance to false when using Docker Buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: ${{ env.IMAGE_NAME }}:${{ steps.patch.outputs.patch }}-${{ steps.local-tag.outputs.value }}
           build-args: |
             REACT_APP_GIT_VERSION=${{ steps.patch.outputs.patch }}-${{ steps.local-tag.outputs.value }}


### PR DESCRIPTION
See context on why it breaks GitHub Container Registry. https://github.com/docker/build-push-action/issues/778