### PR TITLE
Adding Google Analytics 4 to the LinkedDataViewer (on multiple pages)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,12 +9,16 @@ const package = require("./package.json");
 const version = process.env.REACT_APP_GIT_VERSION || package.version;
 
 let env = null;
+let ga4TagCode = null;
 if (version.includes("dev")) {
   env = "test";
+  ga4TagCode = "G-SV1R8XF9RD";
 } else if (version.includes("local")) {
   env = "local";
+  ga4TagCode = "G-SV1R8XF9RD";
 } else {
   env = "prod";
+  ga4TagCode = "G-9ZSB7J0E6H";
 }
 
 /** @type {import('@docusaurus/types').Config} */
@@ -30,9 +34,18 @@ const config = {
   organizationName: "ternaustralia", // Usually your GitHub org/user name.
   projectName: "linkeddata-site", // Usually your repo name.
 
+  scripts: [
+    {
+      src:
+        `https://www.googletagmanager.com/gtag/js?id=${ga4TagCode}`,
+      async: true,
+    },
+  ],
+
   customFields: {
     version: version,
     env: env,
+    ga4TagCode: ga4TagCode,
   },
 
   presets: [

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
@@ -6,8 +6,6 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './index.module.css';
 import HomepageFeatures from '../components/HomepageFeatures';
 
-
-function gtag() { dataLayer.push(arguments); };
 
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
@@ -30,8 +28,11 @@ function HomepageHeader() {
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
-  gtag('js', new Date());
-  gtag('config', siteConfig.customFields.ga4TagCode);
+  useEffect(() => {
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', siteConfig.customFields.ga4TagCode);
+  }, []);
   return (
     <Layout
       title={`${siteConfig.title}`}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,8 +6,12 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './index.module.css';
 import HomepageFeatures from '../components/HomepageFeatures';
 
+
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); };
+
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   return (
     <header className={clsx('hero hero--secondary', styles.heroBanner)}>
       <div className="container">
@@ -26,7 +30,9 @@ function HomepageHeader() {
 }
 
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
+  gtag('js', new Date());
+  gtag('config', siteConfig.customFields.ga4TagCode);
   return (
     <Layout
       title={`${siteConfig.title}`}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,7 +7,6 @@ import styles from './index.module.css';
 import HomepageFeatures from '../components/HomepageFeatures';
 
 
-window.dataLayer = window.dataLayer || [];
 function gtag() { dataLayer.push(arguments); };
 
 function HomepageHeader() {

--- a/src/pages/viewers/dawe-vocabs/index.js
+++ b/src/pages/viewers/dawe-vocabs/index.js
@@ -3,8 +3,12 @@ import React from 'react'
 import settings from './_settings'
 import ViewerPage from '../../../components/vocab-viewers/Page'
 
-export default function Page() {
 
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); };
+
+export default function Page() {
+  gtag('event', 'viewer', { 'cv': 'dawe' });
   return (
     <ViewerPage settingsID="nrm" />
   )

--- a/src/pages/viewers/dawe-vocabs/index.js
+++ b/src/pages/viewers/dawe-vocabs/index.js
@@ -1,14 +1,13 @@
-import React from 'react'
+import React from 'react';
 // import styles from './viewer.modules.css'
-import settings from './_settings'
-import ViewerPage from '../../../components/vocab-viewers/Page'
+import settings from './_settings';
+import ViewerPage from '../../../components/vocab-viewers/Page';
 
 
-window.dataLayer = window.dataLayer || [];
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {
-  gtag('event', 'viewer', { 'cv': 'dawe' });
+  gtag('event', 'viewer', { 'cv': 'dawe2' });
   return (
     <ViewerPage settingsID="nrm" />
   )

--- a/src/pages/viewers/dawe-vocabs/index.js
+++ b/src/pages/viewers/dawe-vocabs/index.js
@@ -7,7 +7,7 @@ import ViewerPage from '../../../components/vocab-viewers/Page';
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {
-  gtag('event', 'viewer', { 'cv': 'dawe2' });
+  gtag('event', 'viewer', { 'cv': 'dawe' });
   return (
     <ViewerPage settingsID="nrm" />
   )

--- a/src/pages/viewers/dawe-vocabs/index.js
+++ b/src/pages/viewers/dawe-vocabs/index.js
@@ -5,7 +5,7 @@ import ViewerPage from '../../../components/vocab-viewers/Page';
 export default function Page() {
   useEffect(() => {
     function gtag() { dataLayer.push(arguments); }
-    gtag('event', 'viewer', { 'cv': 'dawe3' });
+    gtag('event', 'viewer', { 'cv': 'dawe' });
   }, []);
 
   return (

--- a/src/pages/viewers/dawe-vocabs/index.js
+++ b/src/pages/viewers/dawe-vocabs/index.js
@@ -1,13 +1,13 @@
-import React from 'react';
-// import styles from './viewer.modules.css'
-import settings from './_settings';
+import React, { useEffect } from 'react';
 import ViewerPage from '../../../components/vocab-viewers/Page';
 
 
-function gtag() { dataLayer.push(arguments); };
-
 export default function Page() {
-  gtag('event', 'viewer', { 'cv': 'dawe' });
+  useEffect(() => {
+    function gtag() { dataLayer.push(arguments); }
+    gtag('event', 'viewer', { 'cv': 'dawe3' });
+  }, []);
+
   return (
     <ViewerPage settingsID="nrm" />
   )

--- a/src/pages/viewers/tern-loc-ontology/index.js
+++ b/src/pages/viewers/tern-loc-ontology/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ViewerPage from '../../../components/ontology-viewers/Page';
 import settings from './_settings';
 
@@ -6,7 +6,10 @@ import settings from './_settings';
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {
-  gtag('event', 'viewer', { 'cv': 'tern-loc-ontology' });
+  useEffect(() => {
+    function gtag() { dataLayer.push(arguments); }
+    gtag('event', 'viewer', { 'cv': 'tern-loc-ontology' });
+  }, []);
   return (
     <ViewerPage settings={settings} />
   )

--- a/src/pages/viewers/tern-loc-ontology/index.js
+++ b/src/pages/viewers/tern-loc-ontology/index.js
@@ -2,7 +2,12 @@ import React from 'react'
 import ViewerPage from '../../../components/ontology-viewers/Page'
 import settings from './_settings'
 
+
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); };
+
 export default function Page() {
+  gtag('event', 'viewer', { 'cv': 'tern-loc-ontology' });
   return (
     <ViewerPage settings={settings} />
   )

--- a/src/pages/viewers/tern-loc-ontology/index.js
+++ b/src/pages/viewers/tern-loc-ontology/index.js
@@ -1,9 +1,8 @@
-import React from 'react'
-import ViewerPage from '../../../components/ontology-viewers/Page'
-import settings from './_settings'
+import React from 'react';
+import ViewerPage from '../../../components/ontology-viewers/Page';
+import settings from './_settings';
 
 
-window.dataLayer = window.dataLayer || [];
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {

--- a/src/pages/viewers/tern-ontology/index.js
+++ b/src/pages/viewers/tern-ontology/index.js
@@ -2,7 +2,12 @@ import React from 'react'
 import ViewerPage from '../../../components/ontology-viewers/Page'
 import settings from './_settings'
 
+
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); };
+
 export default function Page() {
+  gtag('event', 'viewer', { 'cv': 'tern-ontology' });
   return (
     <ViewerPage settings={settings} />
   )

--- a/src/pages/viewers/tern-ontology/index.js
+++ b/src/pages/viewers/tern-ontology/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ViewerPage from '../../../components/ontology-viewers/Page';
 import settings from './_settings';
 
@@ -6,7 +6,10 @@ import settings from './_settings';
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {
-  gtag('event', 'viewer', { 'cv': 'tern-ontology' });
+  useEffect(() => {
+    function gtag() { dataLayer.push(arguments); }
+    gtag('event', 'viewer', { 'cv': 'tern-ontology' });
+  }, []);
   return (
     <ViewerPage settings={settings} />
   )

--- a/src/pages/viewers/tern-ontology/index.js
+++ b/src/pages/viewers/tern-ontology/index.js
@@ -1,9 +1,8 @@
-import React from 'react'
-import ViewerPage from '../../../components/ontology-viewers/Page'
-import settings from './_settings'
+import React from 'react';
+import ViewerPage from '../../../components/ontology-viewers/Page';
+import settings from './_settings';
 
 
-window.dataLayer = window.dataLayer || [];
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {

--- a/src/pages/viewers/tern-org-ontology/index.js
+++ b/src/pages/viewers/tern-org-ontology/index.js
@@ -2,7 +2,12 @@ import React from 'react'
 import ViewerPage from '../../../components/ontology-viewers/Page'
 import settings from './_settings'
 
+
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); };
+
 export default function Page() {
+  gtag('event', 'viewer', { 'cv': 'tern-org-ontology' });
   return (
     <ViewerPage settings={settings} />
   )

--- a/src/pages/viewers/tern-org-ontology/index.js
+++ b/src/pages/viewers/tern-org-ontology/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ViewerPage from '../../../components/ontology-viewers/Page';
 import settings from './_settings';
 
@@ -6,7 +6,10 @@ import settings from './_settings';
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {
-  gtag('event', 'viewer', { 'cv': 'tern-org-ontology' });
+  useEffect(() => {
+    function gtag() { dataLayer.push(arguments); }
+    gtag('event', 'viewer', { 'cv': 'tern-org-ontology' });
+  }, []);
   return (
     <ViewerPage settings={settings} />
   )

--- a/src/pages/viewers/tern-org-ontology/index.js
+++ b/src/pages/viewers/tern-org-ontology/index.js
@@ -1,9 +1,8 @@
-import React from 'react'
-import ViewerPage from '../../../components/ontology-viewers/Page'
-import settings from './_settings'
+import React from 'react';
+import ViewerPage from '../../../components/ontology-viewers/Page';
+import settings from './_settings';
 
 
-window.dataLayer = window.dataLayer || [];
 function gtag() { dataLayer.push(arguments); };
 
 export default function Page() {


### PR DESCRIPTION
Due to the use of Docusaurus libraries, we are not able to use React Helmet as we do in other TERN project to set up the HTML code for using GA4... 

Docusaurus has its own GA plugin, but this does not work on Docusaurus 2.0.0.beta14 (current version used).
We cannot easily update current version because of plenty of breaking changes introduced before the RC of v2.0.

Because of all this, in order to properly use gtag function, we need to add these lines of code in every file we want to tag an event:

window.dataLayer = window.dataLayer || [];
function gtag() { dataLayer.push(arguments); };

A better solution is welcome, otherwise this solution works fine...