### PR TITLE
Fixed DCCEEW's SPARQL endpoint for local test

### DIFF
--- a/src/hooks/useViewerSettings.js
+++ b/src/hooks/useViewerSettings.js
@@ -17,7 +17,7 @@ export const useViewerSettings = (key) => {
       api: localApiEndpoint,
       pageRoute: "/viewers/dawe-vocabs",
       sparqlEndpoint:
-        "https://graphdb.tern.org.au/repositories/dawe_vocabs_core?infer=false",
+        "http://host.docker.internal:7200/repositories/dawe_vocabs_core?infer=false",
     },
     tern: {
       title: "TERN Controlled Vocabularies",


### PR DESCRIPTION
The local GraphDB is running in a docker container in the local viewer of DCCEEW project, so updated the local API endpoint to `http:host.docker.internal:7200`. Tested locally.